### PR TITLE
manifest: opengapps: update remote name

### DIFF
--- a/snippets/opengapps.xml
+++ b/snippets/opengapps.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote name="opengapps"
-          fetch="https://github.com/opengapps/" />
+  <remote name="nezor"
+          fetch="https://gitlab.nezorfla.me/opengapps/" />
 
   <!-- General repos -->
   <project path="vendor/opengapps/build" name="vendor_opengapps_build" remote="pixel" />
-  <project path="vendor/opengapps/sources/all" name="all" clone-depth="1" revision="master" remote="opengapps" />
-  <project path="vendor/opengapps/sources/arm" name="arm" clone-depth="1" revision="master" remote="opengapps" />
-  <project path="vendor/opengapps/sources/arm64" name="arm64" clone-depth="1" revision="master" remote="opengapps" />
+  <project path="vendor/opengapps/sources/all" name="all" clone-depth="1" revision="master" remote="nezor" />
+  <project path="vendor/opengapps/sources/arm" name="arm" clone-depth="1" revision="master" remote="nezor" />
+  <project path="vendor/opengapps/sources/arm64" name="arm64" clone-depth="1" revision="master" remote="nezor" />
 
 </manifest>


### PR DESCRIPTION
As opengapps had problems with the github's service terms (https://opengapps.org/blog/post/2019/02/17/github-situation/), the build server was replaced with another address.
The update resolves the sync error.