### PR TITLE
manifest: Merge tag 'android-8.1.0_r65' into oreo-mr1

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -8,7 +8,7 @@
   <remote name="github"
           fetch="https://github.com/" />
 
-  <default revision="refs/tags/android-8.1.0_r52"
+  <default revision="refs/tags/android-8.1.0_r65"
            remote="aosp"
            sync-j="4"
            sync-c="true"


### PR DESCRIPTION
I saw a couple of requests on your last commit to PE Oreo. I thought I'll update it so that they can make use of the latest Oreo.